### PR TITLE
[fix] Retrurn empty block when no has products

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,10 +81,11 @@ vtex install vtex.similar-products-variants
 
 To apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles | 
-| ----------- |
-| `variants`  |
-| `title`     |
-| `var-wrap`  |
-| `img_wrap`  |
-| `img`       |
+| CSS Handles            |
+| -----------            |
+| `variants`             |
+| `title`                |
+| `var-wrap`             |
+| `img_wrap`             |
+| `img_wrap--is-active`  |
+| `img`                  |

--- a/react/Index.tsx
+++ b/react/Index.tsx
@@ -69,6 +69,10 @@ function SimilarProductsVariants({
     if (item) items.push(item)
   })
 
+  if( items.length == 0 ){
+    return <></>
+  }
+
   return (
     <div className={`${handles.variants}`}>
       <p className={`${handles.title}`}>{intl.formatMessage({ id: "store/title.label" })}</p>

--- a/react/Index.tsx
+++ b/react/Index.tsx
@@ -86,18 +86,16 @@ function SimilarProductsVariants({
 
           const srcImage = element.items[0].images[imageIndex].imageUrl
           return (
-            <Link {...{
+            <Link 
+              key={element.productId}
+              className={`${handles.img_wrap}${route?.params?.slug === element.linkText ? '--is-active' : ''}`}
+              {...{
               page: 'store.product',
               params: {
-                slug: element?.linkText,
-                id: element?.productId,
+              slug: element?.linkText,
+              id: element?.productId,
               },
             }}>
-              <a
-                key={element.productId}
-                className={`${handles.img_wrap}${route?.params?.slug === element.linkText ? '--is-active' : ''
-                  }`}
-              >
                 <img
                   src={srcImage}
                   alt={element.productName}
@@ -106,7 +104,6 @@ function SimilarProductsVariants({
                     }`
                   }
                 />
-              </a>
             </Link>
           )
         })}


### PR DESCRIPTION
**What problem is this solving?**
- Hidden title(block) when not has product similar
- Tag `<a/>` without css handler and with duplicate `<a/>` in final code

**Screenshots or example usage**
- title without products similars
![image](https://user-images.githubusercontent.com/16208496/167419099-ad65fc36-4c77-41b4-88be-b38d8bc8a823.png)

- Tag `<a />` without css handler exemple
![image](https://user-images.githubusercontent.com/16208496/167420591-0cd27e34-bfb8-462a-a83d-7290f2ed2593.png)

